### PR TITLE
docs(README): Add webgif as an alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ There are following alternative tools solving this problem:
 
 - [tav/asciinema2gif](https://github.com/tav/asciinema2gif)
 - [pettarin/asciicast2gif](https://github.com/pettarin/asciicast2gif)
+- [anishkny/webgif](https://github.com/anishkny/webgif)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ There are following alternative tools solving this problem:
 
 - [tav/asciinema2gif](https://github.com/tav/asciinema2gif)
 - [pettarin/asciicast2gif](https://github.com/pettarin/asciicast2gif)
-- [anishkny/webgif](https://github.com/anishkny/webgif) - `npm i -g webgif && webgif https://asciinema.org/a/147023?t=0`
+- [anishkny/webgif](https://github.com/anishkny/webgif) - `npm i -g webgif && webgif -u https://asciinema.org/a/147023?t=0`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ There are following alternative tools solving this problem:
 
 - [tav/asciinema2gif](https://github.com/tav/asciinema2gif)
 - [pettarin/asciicast2gif](https://github.com/pettarin/asciicast2gif)
-- [anishkny/webgif](https://github.com/anishkny/webgif)
+- [anishkny/webgif](https://github.com/anishkny/webgif) - `npm i -g webgif && webgif https://asciinema.org/a/147023?t=0`
 
 ## License
 


### PR DESCRIPTION
[webgif](https://github.com/anishkny/webgif) uses [Chrome Puppeteer](https://github.com/GoogleChrome/puppeteer) for a seamless, headless, cross-platform (yes [Windows](https://ci.appveyor.com/project/anishkny/webgif/branch/master) too!) GIF generation experience. You can use it in a straightforward manner to generate GIFs from asciinema:

```
npm i -g webgif
webgif --url https://asciinema.org/a/147023?t=0 --duration 60 --output asciinema.gif
```

**No docker needed!**