### PR TITLE
Incorrect npm install intruction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ when using Docker image you need to pass it via Docker's `-e` option.
 
 To install asciicast2gif using `npm` run:
 
-    npm install asciicast2gif
+    npm install --global asciicast2gif
 
 Following runtime dependencies need to be also installed:
 


### PR DESCRIPTION
npm install asciicast2gif will install as module in present working directory.
npm install -g asciicast2gif or npm install --global asciicast2gif will allow to use asciicast2gif as command which can be run from anywhere.