### PR TITLE
Add support for rendering Braille symbols on macOS

### DIFF
--- a/page/asciinema-player.css
+++ b/page/asciinema-player.css
@@ -141,7 +141,7 @@
   border-style: solid;
   cursor: text;
   border-width: 0.5em;
-  font-family: Consolas, Menlo, 'Bitstream Vera Sans Mono', monospace, 'Powerline Symbols';
+  font-family: Consolas, Menlo, 'Bitstream Vera Sans Mono', monospace, 'Powerline Symbols', 'Apple Braille';
   line-height: 1.3333333333em;
 }
 .asciinema-terminal .line {


### PR DESCRIPTION
Hi!

I have [this screenshot containing braille characters](https://github.com/walles/px#ptop):
![example recording](https://github.com/walles/px/raw/python/doc/ptop-screenshot.gif "Example recording")

To be able to record it on my Mac, I had to make the modification in this PR.

Before this change, the braille characters just came out blank.

Please merge?

Regards /Johan